### PR TITLE
Set centering to the default

### DIFF
--- a/js/components/AlignmentComponent.js
+++ b/js/components/AlignmentComponent.js
@@ -11,8 +11,8 @@ class AlignmentComponent extends React.Component {
   _vertical: RadioListComponent<Options.VerticalAlignment>;
 
   componentDidMount(): void {
-    this.setHorizontalAlignment(Options.HorizontalAlignment.LEFT);
-    this.setVerticalAlignment(Options.VerticalAlignment.TOP);
+    this.setHorizontalAlignment(Options.HorizontalAlignment.CENTER);
+    this.setVerticalAlignment(Options.VerticalAlignment.MIDDLE);
   }
 
   getHorizontalAlignment(): ?Options.HorizontalAlignment {


### PR DESCRIPTION
The site is called how to center in CSS. Why is it not the default?
![image](https://user-images.githubusercontent.com/37581230/61577904-68b5c180-ab31-11e9-8c8e-f52ed80014a5.png)
